### PR TITLE
Changed the colors for .default and .cancel state buttons

### DIFF
--- a/Library/PMAlertAction.swift
+++ b/Library/PMAlertAction.swift
@@ -37,7 +37,9 @@ import UIKit
         self.titleLabel?.font = UIFont(name: "Avenir-Heavy", size: 17)
         
         self.actionStyle = style
-        style == .default ? (self.setTitleColor(UIColor(red: 191.0/255.0, green: 51.0/255.0, blue: 98.0/255.0, alpha: 1.0), for: UIControl.State())) : (self.setTitleColor(UIColor.gray, for: UIControl.State()))
+        style == .default
+            ? (self.setTitleColor(UIColor.gray, for: UIControl.State()))
+            : (self.setTitleColor(UIColor(red: 191.0/255.0, green: 51.0/255.0, blue: 98.0/255.0, alpha: 1.0), for: UIControl.State()))
         
         self.addSeparator()
     }


### PR DESCRIPTION
The order of the ternary operator's arguments seems to be inverted.
Sounds like the red color should be applied to the .cancel state. And grey should be used for the .default state.